### PR TITLE
mktemp compatibility for Alpine linux/busybox

### DIFF
--- a/bin/fleetctl.sh
+++ b/bin/fleetctl.sh
@@ -16,7 +16,7 @@ SSH_OPTIONS="-A $OPTIONS"
 # if fleet unit is defined, cp it to the remote host before execting fleetctl cmd
 if [[ $FLEETW_UNIT && ($FLEETW_UNIT_DATA || $FLEETW_UNIT_FILE) ]]; then
   if [[ $FLEETW_UNIT_DATA ]]; then
-    unitfile=$(mktemp /tmp/fleetrc.XXXX)
+    unitfile=$(mktemp /tmp/fleetrc.XXXXXX)
     echo $FLEETW_UNIT_DATA | base64 -d > $unitfile
   else
     unitfile=$FLEETW_UNIT_FILE


### PR DESCRIPTION
This appears to be an issue with BusyBox's multicall `mktemp` implementation when called from `sh` (couldn't replicate in `bash`). Although the BB binary's the same there appear to be inconsistencies when called from different shells. Discovered via Alpine Linux.

The [Paz scheduler](https://github.com/paz-sh/paz-scheduler) fails when `mktemp`'s TEMPLATE argument uses four `X`s instead of six (i.e. `mktemp /tmp/fleetrc.XXXXXX`):

> Jun 28 11:47:13 paz-01 bash[11406]: {"name":"paz-scheduler_log","hostname":"e0c21892b7ce","pid":6,"level":50,"err":{"message":"Command failed: mktemp: Invalid argument\n","name":"Error","stack":"Error: Command failed: mktemp: Invalid argument\n\n    at /usr/src/app/lib/deploy.js:71:19\n  
> ...
